### PR TITLE
feat: 사용자가 가장 최근에 읽은 스토리 다음 스토리 하이라이트 표시 추가

### DIFF
--- a/src/features/book-detail/components/StoryList.jsx
+++ b/src/features/book-detail/components/StoryList.jsx
@@ -1,4 +1,6 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
 import styled from 'styled-components';
+import { getLastReadStoryId } from '../../../utils/affinityStorage.js';
 
 const Section = styled.section`
   padding: 0;
@@ -30,7 +32,6 @@ const Rail = styled.div`
 const RailHighlight = styled.div`
   position: absolute;
   right: -7px;
-  top: 1px;
   width: 5px;
   height: 43px;
   background: #f6d4ff;
@@ -86,23 +87,113 @@ const LockedItem = styled(Item)`
 `;
 
 export default function StoryList({ stories, onStoryClick, book, activeStoryId }) {
-  const list = stories ?? book?.stories ?? [];
-  if (!Array.isArray(list) || list.length === 0) return null;
+  const [highlightTop, setHighlightTop] = useState(1);
+  const [storageVersion, setStorageVersion] = useState(0);
+  const itemRefs = useRef({});
+
+  const list = useMemo(() => {
+    const storyList = stories ?? book?.stories ?? [];
+    return Array.isArray(storyList) ? storyList : [];
+  }, [stories, book?.stories]);
+
+  // 마지막으로 읽은 스토리 ID 가져오기 (storageVersion이 변경되면 다시 계산)
+  const lastReadStoryId = useMemo(() => getLastReadStoryId(), [storageVersion]);
+
+  // 다음 읽을 스토리 인덱스 찾기
+  const nextStoryIndex = useMemo(() => {
+    // 마지막으로 읽은 스토리 인덱스 찾기
+    let lastReadIndex = -1;
+    list.forEach((story, index) => {
+      if (story.storyId === lastReadStoryId) {
+        lastReadIndex = index;
+      }
+    });
+
+    // 다음 스토리 인덱스 결정
+    let targetIndex = lastReadIndex + 1;
+    
+    // 다음 스토리가 없거나 잠겨있으면 마지막으로 읽은 스토리에 표시
+    if (targetIndex >= list.length || (list[targetIndex] && list[targetIndex].locked)) {
+      targetIndex = Math.max(0, lastReadIndex);
+    }
+
+    // 스토리를 하나도 안 읽은 경우 첫 번째 스토리에 표시
+    if (lastReadIndex === -1) {
+      targetIndex = 0;
+    }
+
+    return targetIndex;
+  }, [list, lastReadStoryId]);
+
+  // RailHighlight 위치 계산
+  useEffect(() => {
+    const itemElement = itemRefs.current[`story-${nextStoryIndex}`];
+    if (itemElement) {
+      const listElement = itemElement.parentElement;
+      if (listElement) {
+        const itemTop = itemElement.offsetTop;
+        setHighlightTop(itemTop + 1);
+      }
+    } else {
+      // 폴백: 아이템 높이와 gap을 기반으로 계산
+      // 아이템 높이: padding(14px * 2) + 텍스트 높이(약 13px) = 약 41px
+      // gap: 8px
+      // 총: 49px
+      const itemHeight = 49; // 대략적인 값
+      setHighlightTop(1 + nextStoryIndex * itemHeight);
+    }
+  }, [nextStoryIndex, list]);
+
+  // localStorage 변경 감지
+  useEffect(() => {
+    const handleStorageChange = (e) => {
+      // 다른 탭에서 last_read_story 또는 completed_stories가 변경된 경우에만 업데이트
+      if (!e || e.key === 'last_read_story' || e.key === 'completed_stories') {
+        setStorageVersion(prev => prev + 1);
+      }
+    };
+
+    const handleCustomEvent = () => {
+      // 같은 탭에서의 변경 감지
+      setStorageVersion(prev => prev + 1);
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    // 같은 탭에서의 변경도 감지하기 위해 커스텀 이벤트 리스너 추가
+    window.addEventListener('affinityUpdated', handleCustomEvent);
+    window.addEventListener('lastReadStoryUpdated', handleCustomEvent);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('affinityUpdated', handleCustomEvent);
+      window.removeEventListener('lastReadStoryUpdated', handleCustomEvent);
+    };
+  }, []);
+
+  if (list.length === 0) return null;
 
   return (
     <Section>
       <SectionTitle>5가지 이야기</SectionTitle>
       <List>
         <Rail />
-        <RailHighlight />
-        {list.map((story) => {
+        <RailHighlight 
+          style={{ top: `${highlightTop}px` }}
+        />
+        {list.map((story, index) => {
           const isActive = activeStoryId && activeStoryId === story.storyId;
           const isLocked = story.locked === true;
+          const isNextStory = index === nextStoryIndex;
           const ItemComponent = isLocked ? LockedItem : Item;
           
           return (
             <ItemComponent
               key={story.storyId}
+              ref={(el) => {
+                if (el) {
+                  itemRefs.current[`story-${index}`] = el;
+                }
+              }}
               onClick={() => !isLocked && onStoryClick?.(story.viewpointsDataUrl)}
               disabled={isLocked}
               data-story-id={story.storyId}
@@ -110,11 +201,27 @@ export default function StoryList({ stories, onStoryClick, book, activeStoryId }
             >
               {isLocked ? (
                 <TitleWrapper>
-                  <StoryTitle style={isActive ? { color: '#f6d4ff' } : undefined}>{story.title}</StoryTitle>
+                  <StoryTitle 
+                    style={
+                      isActive || isNextStory 
+                        ? { color: '#f6d4ff' } 
+                        : undefined
+                    }
+                  >
+                    {story.title}
+                  </StoryTitle>
                   <LockIcon src="/images/story-lock.svg" alt="locked" />
                 </TitleWrapper>
               ) : (
-                <StoryTitle style={isActive ? { color: '#f6d4ff' } : undefined}>{story.title}</StoryTitle>
+                <StoryTitle 
+                  style={
+                    isActive || isNextStory 
+                      ? { color: '#f6d4ff' } 
+                      : undefined
+                  }
+                >
+                  {story.title}
+                </StoryTitle>
               )}
             </ItemComponent>
           );


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix로 시작해 주세요!
feat: (기능 개발)
fix: (버그 수정)
style: (CSS 스타일 수정)
format: (코드 스타일 수정)
test: (테스트 코드)
docs: (문서 작업)
refactor: (리팩토링)
lib: (라이브러리)
config: (환경설정)
chore: (기타 단순 작업)

ex) feat: 로그인 기능 구현
-->

📄 작업 내용

<!--
이 PR이 해결하려는 문제나 추가하려는 기능에 대해 간단히 설명해 주세요.
-->

📌 주요 변경 사항

- affinityStorage.js: 
  - LAST_READ_STORY_KEY 상수 추가
  - markStoryAsCompleted에서 스토리 완료 시 마지막으로 읽은 스토리 ID 저장
  - getLastReadStoryId() 함수 추가: 마지막으로 읽은 스토리 ID 반환
  - lastReadStoryUpdated 이벤트 발생

- StoryList.jsx:
  - getLastReadStoryId()로 마지막으로 읽은 스토리 ID 조회
  - 해당 스토리의 다음 스토리 인덱스 계산
  
**동작 방식**
- 스토리를 하나도 안 읽은 경우: 첫 번째 스토리에 하이라이트
- 일부 스토리를 읽은 경우: 마지막으로 읽은 스토리의 다음 스토리에 하이라이트
- 다음 스토리가 잠겨있거나 없는 경우: 마지막으로 읽은 스토리에 하이라이트 (예: 3번째까지 다 읽으면 3번째에 표시)
스토리를 읽으면 하이라이트가 자동으로 업데이트됩니다.

📸 스크린샷 (선택)

<!--
UI 변경이 있다면 스크린샷을 첨부해 주세요. (GIF, PNG, JPG 등)
-->

🧐 리뷰 포인트

<!--
리뷰어가 특별히 중점적으로 봐주길 바라는 부분을 자유롭게 적어주세요.
(ex: 이 부분 로직이 맞는지 봐주세요, 네이밍이 적절한지 봐주세요 등)
-->

🚀 관련 이슈

<!--
관련된 이슈 번호를 작성해 주세요.
(ex: Close #123)

이슈가 없는 경우 "없음"이라고 작성해 주세요.
-->

- 닫기: Close #
- 관련: Relate #
