### PR TITLE
style: StoryEndScreen 에서 메시지 박스 위치 중앙정렬, 상단 텍스트위치와 박스 반응형 설정

### DIFF
--- a/src/features/story-viewer/components/StoryEndScreen.jsx
+++ b/src/features/story-viewer/components/StoryEndScreen.jsx
@@ -14,7 +14,7 @@ const Container = styled.div`
 
 const TopMessageArea = styled.div`
   position: absolute;
-  top: 106px;
+  top: clamp(80px, 13.05vh, 150px);
   left: 29px;
   display: flex;
   flex-direction: column;
@@ -46,10 +46,10 @@ const RelationshipUpdate = styled.div`
 const StatusCardWrapper = styled.div`
   position: absolute;
   left: 50%;
-  top: 274px;
-  transform: translateX(-50%);
-  width: 236px;
-  height: 264px;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: clamp(200px, 62.933vw, 350px);
+  height: clamp(220px, 32.512vh, 400px);
   padding: 15px;
   box-sizing: border-box;
 `;
@@ -62,8 +62,8 @@ const StatusCard = styled.div`
   background: #151515;
   border-radius: 20px;
   padding: 40px 15px;
-  width: 236px;
-  height: 264px;
+  width: 100%;
+  height: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -141,7 +141,9 @@ const Message = styled.div`
 `;
 
 const ProgressBarContainer = styled.div`
-  width: 206px;
+  width: 87.288%;
+  max-width: 306px;
+  min-width: 175px;
   height: 7px;
   margin-top: 0;
   margin-bottom: 14px;
@@ -173,7 +175,7 @@ const NextButton = styled.button`
   border: none;
   border-radius: 10px;
   padding: 6px 139px;
-  width: 330px;
+  width: clamp(280px, 88vw, 500px);
   height: 48px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix로 시작해 주세요!
feat: (기능 개발)
fix: (버그 수정)
style: (CSS 스타일 수정)
format: (코드 스타일 수정)
test: (테스트 코드)
docs: (문서 작업)
refactor: (리팩토링)
lib: (라이브러리)
config: (환경설정)
chore: (기타 단순 작업)

ex) feat: 로그인 기능 구현
-->

📄 작업 내용

<!--
이 PR이 해결하려는 문제나 추가하려는 기능에 대해 간단히 설명해 주세요.
-->

📌 주요 변경 사항

- StatusCardWrapper를 화면 중앙에 배치하도록 수정
- StatusCardWrapper와 StatusCard, ProgressBarContainer, NextButton를 비율 기반 반응형으로 수정
  - width: clamp(200px, 62.933vw, 350px) - 최소 200px, 최대 350px, 기준 비율 62.933vw 이런 식으로
- TopMessageArea의 top 위치를 반응형으로 수정
  - top: clamp(80px, 13.05vh, 150px) - 최소 80px, 최대 150px, 기준 비율 13.05vh
  - 기준 화면(세로 812px)에서 106px로 표시됩니다
  - 화면 높이에 비례해 위치가 조정되며, min/max로 제한됩니다.

📸 스크린샷 (선택)

<!--
UI 변경이 있다면 스크린샷을 첨부해 주세요. (GIF, PNG, JPG 등)
-->

🧐 리뷰 포인트

<!--
리뷰어가 특별히 중점적으로 봐주길 바라는 부분을 자유롭게 적어주세요.
(ex: 이 부분 로직이 맞는지 봐주세요, 네이밍이 적절한지 봐주세요 등)
-->

🚀 관련 이슈

<!--
관련된 이슈 번호를 작성해 주세요.
(ex: Close #123)

이슈가 없는 경우 "없음"이라고 작성해 주세요.
-->

- 닫기: Close #
- 관련: Relate #
