### PR TITLE
fix: 목데이터 모드에서 baseURL을 빈 문자열로 설정

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+VITE_USE_MOCK_DATA=true
+
+# API Base URL (실제 백엔드 서버 주소)
+# VITE_API_BASE_URL=https://api.yourdomain.com

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -5,8 +5,14 @@
 
 import axios from 'axios';
 
+// 목 데이터 사용 여부 (환경 변수로 제어)
+const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true';
+
 // 개발 환경에서는 로컬 API 서버, 프로덕션에서는 실제 API 서버
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
+// 목 데이터 모드일 때는 baseURL을 빈 문자열로 설정 (상대 경로 사용)
+const API_BASE_URL = USE_MOCK_DATA 
+  ? '' 
+  : (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080');
 
 // 또는 상대 경로를 사용하는 경우 (프록시 설정 시)
 // const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix로 시작해 주세요!
feat: (기능 개발)
fix: (버그 수정)
style: (CSS 스타일 수정)
format: (코드 스타일 수정)
test: (테스트 코드)
docs: (문서 작업)
refactor: (리팩토링)
lib: (라이브러리)
config: (환경설정)
chore: (기타 단순 작업)

ex) feat: 로그인 기능 구현
-->

📄 작업 내용

<!--
이 PR이 해결하려는 문제나 추가하려는 기능에 대해 간단히 설명해 주세요.
-->

📌 주요 변경 사항

<!--
어떤 부분이 바뀌었나요?
(스크린샷 등과 함께 작성하면 좋습니다.)

[ ] (예: 로그인 API 연동)

[ ] (예: 로그인 버튼 스타일 수정)
-->

[ ]

[ ]

📸 스크린샷 (선택)

<!--
UI 변경이 있다면 스크린샷을 첨부해 주세요. (GIF, PNG, JPG 등)
-->

🧐 리뷰 포인트

<!--
리뷰어가 특별히 중점적으로 봐주길 바라는 부분을 자유롭게 적어주세요.
(ex: 이 부분 로직이 맞는지 봐주세요, 네이밍이 적절한지 봐주세요 등)
-->

목 데이터 모드에서 실제 API 모드로 전환하려면:
- VITE_USE_MOCK_DATA=false로 변경
- VITE_API_BASE_URL에 실제 서버 주소 입력

자세한 API 연동 방법과 관련 코드 설명은 API_INTEGRATION_GUIDE.md  참고

🚀 관련 이슈

<!--
관련된 이슈 번호를 작성해 주세요.
(ex: Close #123)

이슈가 없는 경우 "없음"이라고 작성해 주세요.
-->

- 닫기: Close #
- 관련: Relate #
