### PR TITLE
fix: 비디오 로드 코드 수정, 스토리 읽기 목데이터 수정, 스토리 완료 화면으로 넘어가는 코드 수정

### DIFF
--- a/public/data/story-content/1/1/18.json
+++ b/public/data/story-content/1/1/18.json
@@ -9,5 +9,6 @@
       "text": "무슨 일이 있었는데?",
       "nextId": 19
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/19.json
+++ b/public/data/story-content/1/1/19.json
@@ -9,5 +9,6 @@
       "text": "그 사람이랑 무슨 일 있었어?",
       "nextId": 20
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/20.json
+++ b/public/data/story-content/1/1/20.json
@@ -13,5 +13,6 @@
       "text": "잘못 들은 거 아니야?",
       "nextId": 21
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/21.json
+++ b/public/data/story-content/1/1/21.json
@@ -9,5 +9,6 @@
       "text": "너도 그 사람한테 한마디 해야지.",
       "nextId": 22
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/22.json
+++ b/public/data/story-content/1/1/22.json
@@ -9,5 +9,6 @@
       "text": "내가 생각해도 그래!",
       "nextId": 23
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/23.json
+++ b/public/data/story-content/1/1/23.json
@@ -9,5 +9,6 @@
       "text": "괜히 신경 쓰였겠다.",
       "nextId": 24
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/24.json
+++ b/public/data/story-content/1/1/24.json
@@ -9,5 +9,6 @@
       "text": "그래서 지금 기분은 어때?",
       "nextId": 25
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/1/25.json
+++ b/public/data/story-content/1/1/25.json
@@ -8,5 +8,6 @@
     {
       "text": "다행이다! 다음에 또 얘기하자."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/1/2/10.json
+++ b/public/data/story-content/1/2/10.json
@@ -9,5 +9,6 @@
       "text": "근데, 무슨 일 있었어?",
       "nextId": 11
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/11.json
+++ b/public/data/story-content/1/2/11.json
@@ -9,5 +9,6 @@
       "text": "그래서 뭐라고 했는데?",
       "nextId": 12
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/12.json
+++ b/public/data/story-content/1/2/12.json
@@ -13,5 +13,6 @@
       "text": "왜 저렇게 말한 거야...?",
       "nextId": 14
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/13.json
+++ b/public/data/story-content/1/2/13.json
@@ -9,5 +9,6 @@
       "text": "우연 아닐까?",
       "nextId": 14
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/14.json
+++ b/public/data/story-content/1/2/14.json
@@ -9,5 +9,6 @@
       "text": "헉... 그래서?",
       "nextId": 15
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/15.json
+++ b/public/data/story-content/1/2/15.json
@@ -13,5 +13,6 @@
       "text": "특별한 경험을 했네!",
       "nextId": 17
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/16.json
+++ b/public/data/story-content/1/2/16.json
@@ -9,5 +9,6 @@
       "text": "너한테는 좀 특별한 날이었네.",
       "nextId": 17
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/2/17.json
+++ b/public/data/story-content/1/2/17.json
@@ -8,5 +8,6 @@
     {
       "text": "오늘도 재밌었어!"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/1/3/26.json
+++ b/public/data/story-content/1/3/26.json
@@ -9,5 +9,6 @@
       "text": "누굴 만났는데?",
       "nextId": 27
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/27.json
+++ b/public/data/story-content/1/3/27.json
@@ -9,5 +9,6 @@
       "text": "빙리가 마음에 들었구나?",
       "nextId": 28
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/28.json
+++ b/public/data/story-content/1/3/28.json
@@ -13,5 +13,6 @@
       "text": "빙리 얘기 좀 더 해줘",
       "nextId": 29
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/29.json
+++ b/public/data/story-content/1/3/29.json
@@ -9,5 +9,6 @@
       "text": "완벽한 신사를 만났네!",
       "nextId": 30
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/30.json
+++ b/public/data/story-content/1/3/30.json
@@ -9,5 +9,6 @@
       "text": "무슨 일 있었대?",
       "nextId": 31
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/31.json
+++ b/public/data/story-content/1/3/31.json
@@ -9,5 +9,6 @@
       "text": "그래서 엘리자베스가 속상해했어?",
       "nextId": 32
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/32.json
+++ b/public/data/story-content/1/3/32.json
@@ -13,5 +13,6 @@
       "text": "네가 많이 신경 쓰였겠네.",
       "nextId": 34
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/33.json
+++ b/public/data/story-content/1/3/33.json
@@ -9,5 +9,6 @@
       "text": "다행이다. 좋은 하루였네.",
       "nextId": 34
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/3/34.json
+++ b/public/data/story-content/1/3/34.json
@@ -8,5 +8,6 @@
     {
       "text": "나도 덩달아 기분이 좋네."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/1/4/1.json
+++ b/public/data/story-content/1/4/1.json
@@ -9,5 +9,6 @@
       "text": "누굴 만났는데?",
       "nextId": 2
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/2.json
+++ b/public/data/story-content/1/4/2.json
@@ -13,5 +13,6 @@
       "text": "그 얘기 좀 더 해봐",
       "nextId": 3
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/3.json
+++ b/public/data/story-content/1/4/3.json
@@ -9,5 +9,6 @@
       "text": "무슨 일이 있었는데?",
       "nextId": 5
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/4.json
+++ b/public/data/story-content/1/4/4.json
@@ -9,5 +9,6 @@
       "text": "무슨 일이 있었는데?",
       "nextId": 5
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/5.json
+++ b/public/data/story-content/1/4/5.json
@@ -9,5 +9,6 @@
       "text": "엘리자베스가 상처받았겠는 걸",
       "nextId": 6
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/6.json
+++ b/public/data/story-content/1/4/6.json
@@ -13,5 +13,6 @@
       "text": "신경 쓰였겠다.",
       "nextId": 7
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/7.json
+++ b/public/data/story-content/1/4/7.json
@@ -9,5 +9,6 @@
       "text": "첫만남에 이런 일이 생기다니!",
       "nextId": 8
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/8.json
+++ b/public/data/story-content/1/4/8.json
@@ -9,5 +9,6 @@
       "text": "그랬겠다. 어떡해!",
       "nextId": 9
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/1/4/9.json
+++ b/public/data/story-content/1/4/9.json
@@ -8,5 +8,6 @@
     {
       "text": "즐거웠어, 빙리!"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/1/51.json
+++ b/public/data/story-content/2/1/51.json
@@ -9,5 +9,6 @@
       "text": "다아시가 빙리의 결혼을 막았다는 거야?",
       "nextId": 52
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/52.json
+++ b/public/data/story-content/2/1/52.json
@@ -13,5 +13,6 @@
       "text": "듣자마자 제인이 떠올랐어?",
       "nextId": 53
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/53.json
+++ b/public/data/story-content/2/1/53.json
@@ -9,5 +9,6 @@
       "text": "속상했겠다.",
       "nextId": 54
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/54.json
+++ b/public/data/story-content/2/1/54.json
@@ -9,5 +9,6 @@
       "text": "직접 따질 기회는 없었어?",
       "nextId": 55
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/55.json
+++ b/public/data/story-content/2/1/55.json
@@ -9,5 +9,6 @@
       "text": "다아시는 뭐라고 했어?",
       "nextId": 56
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/56.json
+++ b/public/data/story-content/2/1/56.json
@@ -13,5 +13,6 @@
       "text": "그래도 다른 사람 얘길 수도 있지 않아?",
       "nextId": 57
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/57.json
+++ b/public/data/story-content/2/1/57.json
@@ -9,5 +9,6 @@
       "text": "그래서 지금 기분은 어때?",
       "nextId": 58
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/1/58.json
+++ b/public/data/story-content/2/1/58.json
@@ -8,5 +8,6 @@
     {
       "text": "둘이 잘 됐으면 좋겠다.."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/2/2/44.json
+++ b/public/data/story-content/2/2/44.json
@@ -9,5 +9,6 @@
       "text": "무슨 이야기였는데?",
       "nextId": 45
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/2/45.json
+++ b/public/data/story-content/2/2/45.json
@@ -9,5 +9,6 @@
       "text": "그래서 뭐라고 했는데?",
       "nextId": 46
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/2/46.json
+++ b/public/data/story-content/2/2/46.json
@@ -9,5 +9,6 @@
       "text": "그래서 결혼을 다시 생각해보라고 한 거야?",
       "nextId": 47
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/2/47.json
+++ b/public/data/story-content/2/2/47.json
@@ -13,5 +13,6 @@
       "text": "네 생각은 변함없어 보이네.",
       "nextId": 49
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/2/48.json
+++ b/public/data/story-content/2/2/48.json
@@ -9,5 +9,6 @@
       "text": "너가 뭔가 잘못한 걸까?",
       "nextId": 49
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/2/49.json
+++ b/public/data/story-content/2/2/49.json
@@ -9,5 +9,6 @@
       "text": "엘리자베스가 화난 것 같아 보여.",
       "nextId": 50
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/2/50.json
+++ b/public/data/story-content/2/2/50.json
@@ -8,5 +8,6 @@
     {
       "text": "오늘도 많은 일이 있었네."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/2/3/59.json
+++ b/public/data/story-content/2/3/59.json
@@ -9,5 +9,6 @@
       "text": "어떤 느낌이었는데?",
       "nextId": 60
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/60.json
+++ b/public/data/story-content/2/3/60.json
@@ -13,5 +13,6 @@
       "text": "너가 무슨 실수를 해!",
       "nextId": 62
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/61.json
+++ b/public/data/story-content/2/3/61.json
@@ -9,5 +9,6 @@
       "text": "그래, 분명 그런 걸 거야.",
       "nextId": 62
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/62.json
+++ b/public/data/story-content/2/3/62.json
@@ -9,5 +9,6 @@
       "text": "나는 너가 충분히 표현했다고 생각해.",
       "nextId": 63
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/63.json
+++ b/public/data/story-content/2/3/63.json
@@ -9,5 +9,6 @@
       "text": "어떤 표정이었는데?",
       "nextId": 64
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/64.json
+++ b/public/data/story-content/2/3/64.json
@@ -13,5 +13,6 @@
       "text": "네가 너무 걱정하는 건 아닐까?",
       "nextId": 66
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/65.json
+++ b/public/data/story-content/2/3/65.json
@@ -9,5 +9,6 @@
       "text": "네가 많이 신경 쓰였겠네.",
       "nextId": 66
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/66.json
+++ b/public/data/story-content/2/3/66.json
@@ -9,5 +9,6 @@
       "text": "동생한테 잘 말했네.",
       "nextId": 67
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/3/67.json
+++ b/public/data/story-content/2/3/67.json
@@ -8,5 +8,6 @@
     {
       "text": "얘기해줘서 고마워."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/2/4/35.json
+++ b/public/data/story-content/2/4/35.json
@@ -9,5 +9,6 @@
       "text": "무슨 얘길 했길래?",
       "nextId": 36
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/36.json
+++ b/public/data/story-content/2/4/36.json
@@ -13,5 +13,6 @@
       "text": "그 말이 마음에 걸렸나?",
       "nextId": 37
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/37.json
+++ b/public/data/story-content/2/4/37.json
@@ -9,5 +9,6 @@
       "text": "그런 생각이 들 수 있지.",
       "nextId": 39
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/38.json
+++ b/public/data/story-content/2/4/38.json
@@ -9,5 +9,6 @@
       "text": "그래서?",
       "nextId": 39
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/39.json
+++ b/public/data/story-content/2/4/39.json
@@ -9,5 +9,6 @@
       "text": "제인은 뭐라고 했어?",
       "nextId": 40
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/40.json
+++ b/public/data/story-content/2/4/40.json
@@ -13,5 +13,6 @@
       "text": "다아시 말을 너무 신경 쓴 거 아닐까?",
       "nextId": 41
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/41.json
+++ b/public/data/story-content/2/4/41.json
@@ -9,5 +9,6 @@
       "text": "아냐 그럴 수 있지.",
       "nextId": 42
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/42.json
+++ b/public/data/story-content/2/4/42.json
@@ -9,5 +9,6 @@
       "text": "분명 제인도 알 거야!",
       "nextId": 43
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/2/4/43.json
+++ b/public/data/story-content/2/4/43.json
@@ -8,5 +8,6 @@
     {
       "text": "복잡하다. 다음에 또 얘기 들려줘."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/1/86.json
+++ b/public/data/story-content/3/1/86.json
@@ -9,5 +9,6 @@
       "text": "뭐가 그렇게 재밌는 건데?",
       "nextId": 87
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/87.json
+++ b/public/data/story-content/3/1/87.json
@@ -9,5 +9,6 @@
       "text": "신나는 날이었겠다!",
       "nextId": 88
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/88.json
+++ b/public/data/story-content/3/1/88.json
@@ -13,5 +13,6 @@
       "text": "새로운 사람을 사귀었구나.",
       "nextId": 90
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/89.json
+++ b/public/data/story-content/3/1/89.json
@@ -9,5 +9,6 @@
       "text": "엄청 성격이 좋으신가보다.",
       "nextId": 90
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/90.json
+++ b/public/data/story-content/3/1/90.json
@@ -9,5 +9,6 @@
       "text": "둘이 이미 아는 사이인가?",
       "nextId": 91
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/91.json
+++ b/public/data/story-content/3/1/91.json
@@ -9,5 +9,6 @@
       "text": "무슨 얘기였어?",
       "nextId": 92
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/92.json
+++ b/public/data/story-content/3/1/92.json
@@ -13,5 +13,6 @@
       "text": "혹시 위컴의 말이 의심스럽진 않았어?",
       "nextId": 94
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/93.json
+++ b/public/data/story-content/3/1/93.json
@@ -9,5 +9,6 @@
       "text": "다아시는 너한테 자꾸 밉보이게 되네",
       "nextId": 95
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/94.json
+++ b/public/data/story-content/3/1/94.json
@@ -9,5 +9,6 @@
       "text": "그럴 수 있지! 이해해.",
       "nextId": 95
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/1/95.json
+++ b/public/data/story-content/3/1/95.json
@@ -8,5 +8,6 @@
     {
       "text": "그랬겠다. 얘기해줘서 고마워!"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/3/2/77.json
+++ b/public/data/story-content/3/2/77.json
@@ -9,5 +9,6 @@
       "text": "위컴이 누군데?",
       "nextId": 78
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/78.json
+++ b/public/data/story-content/3/2/78.json
@@ -9,5 +9,6 @@
       "text": "어떡해 당황했겠다.",
       "nextId": 79
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/79.json
+++ b/public/data/story-content/3/2/79.json
@@ -13,5 +13,6 @@
       "text": "그냥 두려웠던 거야?",
       "nextId": 80
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/80.json
+++ b/public/data/story-content/3/2/80.json
@@ -9,5 +9,6 @@
       "text": "많이 신경 쓰였겠다.",
       "nextId": 81
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/81.json
+++ b/public/data/story-content/3/2/81.json
@@ -9,5 +9,6 @@
       "text": "그랬구나..",
       "nextId": 82
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/82.json
+++ b/public/data/story-content/3/2/82.json
@@ -13,5 +13,6 @@
       "text": "무슨 얘기였을 것 같아?",
       "nextId": 83
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/83.json
+++ b/public/data/story-content/3/2/83.json
@@ -9,5 +9,6 @@
       "text": "너와 위컴 사이에 많은 일이 있었나보네.",
       "nextId": 85
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/84.json
+++ b/public/data/story-content/3/2/84.json
@@ -9,5 +9,6 @@
       "text": "신경이 쓰일 수 밖에 없겠다.",
       "nextId": 85
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/2/85.json
+++ b/public/data/story-content/3/2/85.json
@@ -8,5 +8,6 @@
     {
       "text": "그 오해, 꼭 풀릴 거야"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/3/3/100.json
+++ b/public/data/story-content/3/3/100.json
@@ -13,5 +13,6 @@
       "text": "너도 이상하다고 느꼈어?",
       "nextId": 102
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/101.json
+++ b/public/data/story-content/3/3/101.json
@@ -9,5 +9,6 @@
       "text": "그랬구나. 둘은 무슨 사이인 걸까?",
       "nextId": 103
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/102.json
+++ b/public/data/story-content/3/3/102.json
@@ -9,5 +9,6 @@
       "text": "둘은 무슨 사이인 걸까?",
       "nextId": 103
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/103.json
+++ b/public/data/story-content/3/3/103.json
@@ -9,5 +9,6 @@
       "text": "엘리자베스에게 물어봤어?",
       "nextId": 104
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/104.json
+++ b/public/data/story-content/3/3/104.json
@@ -8,5 +8,6 @@
     {
       "text": "그러게. 너도 편안했으면 좋겠어."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/96.json
+++ b/public/data/story-content/3/3/96.json
@@ -9,5 +9,6 @@
       "text": "장교들 구경하는 거 재밌어?",
       "nextId": 97
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/97.json
+++ b/public/data/story-content/3/3/97.json
@@ -9,5 +9,6 @@
       "text": "재밌는 하루였겠다!",
       "nextId": 98
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/98.json
+++ b/public/data/story-content/3/3/98.json
@@ -9,5 +9,6 @@
       "text": "그 사람이 위컴이야?",
       "nextId": 99
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/3/99.json
+++ b/public/data/story-content/3/3/99.json
@@ -9,5 +9,6 @@
       "text": "잘 맞는 사람을 만나다니, 잘 됐다!",
       "nextId": 100
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/3/4/68.json
+++ b/public/data/story-content/3/4/68.json
@@ -9,5 +9,6 @@
       "text": "그곳 분위기는 어땠어?",
       "nextId": 69
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/69.json
+++ b/public/data/story-content/3/4/69.json
@@ -9,5 +9,6 @@
       "text": "즐거웠겠다!",
       "nextId": 70
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/70.json
+++ b/public/data/story-content/3/4/70.json
@@ -9,5 +9,6 @@
       "text": "오랜 친구였어?",
       "nextId": 71
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/71.json
+++ b/public/data/story-content/3/4/71.json
@@ -9,5 +9,6 @@
       "text": "애매한 사이구나.",
       "nextId": 72
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/72.json
+++ b/public/data/story-content/3/4/72.json
@@ -9,5 +9,6 @@
       "text": "둘이 사이 안 좋아?",
       "nextId": 73
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/73.json
+++ b/public/data/story-content/3/4/73.json
@@ -9,5 +9,6 @@
       "text": "둘 사이에 대체 무슨 일이 있었던 걸까.",
       "nextId": 74
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/74.json
+++ b/public/data/story-content/3/4/74.json
@@ -13,5 +13,6 @@
       "text": "둘은 무슨 이야기를 나눴던 거야?",
       "nextId": 76
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/75.json
+++ b/public/data/story-content/3/4/75.json
@@ -8,5 +8,6 @@
     {
       "text": "나도 다아시의 기분이 좋아지길 바랄게."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/3/4/76.json
+++ b/public/data/story-content/3/4/76.json
@@ -8,5 +8,6 @@
     {
       "text": "복잡하다. 다음에 또 얘기 들려줘."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/1/123.json
+++ b/public/data/story-content/4/1/123.json
@@ -9,5 +9,6 @@
       "text": "그래서 뭐라고 했어?",
       "nextId": 124
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/124.json
+++ b/public/data/story-content/4/1/124.json
@@ -9,5 +9,6 @@
       "text": "그러게, 이상하다.",
       "nextId": 125
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/125.json
+++ b/public/data/story-content/4/1/125.json
@@ -13,5 +13,6 @@
       "text": "다아시한테 무슨 말이라도 하라고 해봐!",
       "nextId": 127
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/126.json
+++ b/public/data/story-content/4/1/126.json
@@ -9,5 +9,6 @@
       "text": "그러게! 나 같아도 불편할 것 같아.",
       "nextId": 127
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/127.json
+++ b/public/data/story-content/4/1/127.json
@@ -9,5 +9,6 @@
       "text": "놀랐겠다, 다아시는 왜 왔대?",
       "nextId": 128
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/128.json
+++ b/public/data/story-content/4/1/128.json
@@ -9,5 +9,6 @@
       "text": "너가 많이 걱정됐나봐.",
       "nextId": 129
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/129.json
+++ b/public/data/story-content/4/1/129.json
@@ -9,5 +9,6 @@
       "text": "갑자기? 말도 안 돼!",
       "nextId": 130
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/130.json
+++ b/public/data/story-content/4/1/130.json
@@ -9,5 +9,6 @@
       "text": "어떻게 그렇게 오만할 수가..!",
       "nextId": 131
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/131.json
+++ b/public/data/story-content/4/1/131.json
@@ -9,5 +9,6 @@
       "text": "그랬더니 다아시가 뭐래?",
       "nextId": 132
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/1/132.json
+++ b/public/data/story-content/4/1/132.json
@@ -8,5 +8,6 @@
     {
       "text": "편지? 어떤 내용이었어?"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/4/2/114.json
+++ b/public/data/story-content/4/2/114.json
@@ -9,5 +9,6 @@
       "text": "본인도 이상하다고 느꼈어?",
       "nextId": 115
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/115.json
+++ b/public/data/story-content/4/2/115.json
@@ -9,5 +9,6 @@
       "text": "왜 말하지 못했어?",
       "nextId": 116
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/116.json
+++ b/public/data/story-content/4/2/116.json
@@ -9,5 +9,6 @@
       "text": "너 엘리자베스를 많이 좋아하는구나!",
       "nextId": 117
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/117.json
+++ b/public/data/story-content/4/2/117.json
@@ -13,5 +13,6 @@
       "text": "실수의 시작이라니.. 벌써 불안해",
       "nextId": 119
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/118.json
+++ b/public/data/story-content/4/2/118.json
@@ -9,5 +9,6 @@
       "text": "별 일 없어야 할텐데..!",
       "nextId": 119
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/119.json
+++ b/public/data/story-content/4/2/119.json
@@ -9,5 +9,6 @@
       "text": "그래서 고백한 거야?",
       "nextId": 120
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/120.json
+++ b/public/data/story-content/4/2/120.json
@@ -9,5 +9,6 @@
       "text": "왜 그렇게 말한 거야!",
       "nextId": 121
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/121.json
+++ b/public/data/story-content/4/2/121.json
@@ -9,5 +9,6 @@
       "text": "왜 반박하지 않았어?",
       "nextId": 122
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/2/122.json
+++ b/public/data/story-content/4/2/122.json
@@ -8,5 +8,6 @@
     {
       "text": "편지는 진심이 전해지기 마련이지."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/4/3/133.json
+++ b/public/data/story-content/4/3/133.json
@@ -9,5 +9,6 @@
       "text": "왜 불편하대?",
       "nextId": 134
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/134.json
+++ b/public/data/story-content/4/3/134.json
@@ -9,5 +9,6 @@
       "text": "응, 나 같아도 그럴 것 같아.",
       "nextId": 135
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/135.json
+++ b/public/data/story-content/4/3/135.json
@@ -9,5 +9,6 @@
       "text": "너는 어떻게 생각해?",
       "nextId": 136
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/136.json
+++ b/public/data/story-content/4/3/136.json
@@ -9,5 +9,6 @@
       "text": "맞아, 나도 그렇게 생각해!",
       "nextId": 137
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/137.json
+++ b/public/data/story-content/4/3/137.json
@@ -13,5 +13,6 @@
       "text": "많이 놀랐겠다.",
       "nextId": 139
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/138.json
+++ b/public/data/story-content/4/3/138.json
@@ -9,5 +9,6 @@
       "text": "다아시가 고백을 했다고?",
       "nextId": 139
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/139.json
+++ b/public/data/story-content/4/3/139.json
@@ -9,5 +9,6 @@
       "text": "그래서 뭐라고 대답했대?",
       "nextId": 140
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/140.json
+++ b/public/data/story-content/4/3/140.json
@@ -9,5 +9,6 @@
       "text": "그래서 어떻게 됐대?",
       "nextId": 141
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/3/141.json
+++ b/public/data/story-content/4/3/141.json
@@ -8,5 +8,6 @@
     {
       "text": "무슨 편지일까? 궁금해."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/4/4/105.json
+++ b/public/data/story-content/4/4/105.json
@@ -9,5 +9,6 @@
       "text": "뭐가 어떻게 달랐는데?",
       "nextId": 106
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/106.json
+++ b/public/data/story-content/4/4/106.json
@@ -9,5 +9,6 @@
       "text": "무슨 일이 있었던 걸까?",
       "nextId": 107
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/107.json
+++ b/public/data/story-content/4/4/107.json
@@ -9,5 +9,6 @@
       "text": "다아시는 그런 이야길 잘 안 하는구나.",
       "nextId": 108
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/108.json
+++ b/public/data/story-content/4/4/108.json
@@ -9,5 +9,6 @@
       "text": "다아시가 그랬다니 상상이 안 돼!",
       "nextId": 109
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/109.json
+++ b/public/data/story-content/4/4/109.json
@@ -13,5 +13,6 @@
       "text": "엘리자베스가 쌓인 게 많은가봐.",
       "nextId": 111
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/110.json
+++ b/public/data/story-content/4/4/110.json
@@ -9,5 +9,6 @@
       "text": "너무 자책하지 마..!",
       "nextId": 111
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/111.json
+++ b/public/data/story-content/4/4/111.json
@@ -13,5 +13,6 @@
       "text": "마음이 좋지 않네..",
       "nextId": 113
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/112.json
+++ b/public/data/story-content/4/4/112.json
@@ -9,5 +9,6 @@
       "text": "그게 뭔데?",
       "nextId": 113
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/4/4/113.json
+++ b/public/data/story-content/4/4/113.json
@@ -8,5 +8,6 @@
     {
       "text": "그러게! 분명 그럴 거야."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/1/161.json
+++ b/public/data/story-content/5/1/161.json
@@ -9,5 +9,6 @@
       "text": "변명이 아니었어?",
       "nextId": 162
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/162.json
+++ b/public/data/story-content/5/1/162.json
@@ -13,5 +13,6 @@
       "text": "편지를 읽고 기분은 어땠어?",
       "nextId": 164
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/163.json
+++ b/public/data/story-content/5/1/163.json
@@ -9,5 +9,6 @@
       "text": "완전 잘못 생각하고 있었구나..",
       "nextId": 164
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/164.json
+++ b/public/data/story-content/5/1/164.json
@@ -9,5 +9,6 @@
       "text": "그 부분은 이해가 갔어?",
       "nextId": 165
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/165.json
+++ b/public/data/story-content/5/1/165.json
@@ -13,5 +13,6 @@
       "text": "다아시를 다시 보게 됐겠네.",
       "nextId": 167
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/166.json
+++ b/public/data/story-content/5/1/166.json
@@ -9,5 +9,6 @@
       "text": "그럼 다아시가 전과는 달라 보였어?",
       "nextId": 167
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/167.json
+++ b/public/data/story-content/5/1/167.json
@@ -9,5 +9,6 @@
       "text": "가족들 반응은 어땠어?",
       "nextId": 168
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/168.json
+++ b/public/data/story-content/5/1/168.json
@@ -9,5 +9,6 @@
       "text": "너무 무서웠을 것 같아..",
       "nextId": 169
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/169.json
+++ b/public/data/story-content/5/1/169.json
@@ -9,5 +9,6 @@
       "text": "다아시가 해결했다고?",
       "nextId": 170
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/170.json
+++ b/public/data/story-content/5/1/170.json
@@ -9,5 +9,6 @@
       "text": "둘의 결혼을 다아시가 도운 거라니!",
       "nextId": 171
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/171.json
+++ b/public/data/story-content/5/1/171.json
@@ -9,5 +9,6 @@
       "text": "이제야 다아시의 본 모습으르 알았구나!",
       "nextId": 172
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/172.json
+++ b/public/data/story-content/5/1/172.json
@@ -13,5 +13,6 @@
       "text": "내가 다 설레!",
       "nextId": 174
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/173.json
+++ b/public/data/story-content/5/1/173.json
@@ -9,5 +9,6 @@
       "text": "정말 너무 잘 됐다! 내가 더 설레.",
       "nextId": 174
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/1/174.json
+++ b/public/data/story-content/5/1/174.json
@@ -8,5 +8,6 @@
     {
       "text": "그 말 멋진 것 같아."
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/elizabeth-video.mp4"
 }

--- a/public/data/story-content/5/2/151.json
+++ b/public/data/story-content/5/2/151.json
@@ -13,5 +13,6 @@
       "text": "그래도 꼭 전하고 싶었지?",
       "nextId": 153
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/152.json
+++ b/public/data/story-content/5/2/152.json
@@ -9,5 +9,6 @@
       "text": "너는 생각이 꽤 깊은 사람이구나.",
       "nextId": 153
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/153.json
+++ b/public/data/story-content/5/2/153.json
@@ -9,5 +9,6 @@
       "text": "막내와 위컴의 일 말하는 거지?",
       "nextId": 154
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/154.json
+++ b/public/data/story-content/5/2/154.json
@@ -9,5 +9,6 @@
       "text": "그래서 엘리자베스를 도와줬어?",
       "nextId": 155
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/155.json
+++ b/public/data/story-content/5/2/155.json
@@ -9,5 +9,6 @@
       "text": "결혼을 조건으로?",
       "nextId": 156
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/156.json
+++ b/public/data/story-content/5/2/156.json
@@ -9,5 +9,6 @@
       "text": "멋있어, 다아시!",
       "nextId": 157
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/157.json
+++ b/public/data/story-content/5/2/157.json
@@ -9,5 +9,6 @@
       "text": "이제 너에게 기회가 온 걸까?",
       "nextId": 158
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/158.json
+++ b/public/data/story-content/5/2/158.json
@@ -9,5 +9,6 @@
       "text": "두번째 고백이라니!",
       "nextId": 159
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/159.json
+++ b/public/data/story-content/5/2/159.json
@@ -9,5 +9,6 @@
       "text": "정말 잘됐다. 사랑이 이루어졌네.",
       "nextId": 160
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/2/160.json
+++ b/public/data/story-content/5/2/160.json
@@ -8,5 +8,6 @@
     {
       "text": "소중한 얘기 들려줘서 고마워!"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/darcy-video.mp4"
 }

--- a/public/data/story-content/5/3/175.json
+++ b/public/data/story-content/5/3/175.json
@@ -9,5 +9,6 @@
       "text": "어떤 생각이 들었대?",
       "nextId": 176
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/176.json
+++ b/public/data/story-content/5/3/176.json
@@ -9,5 +9,6 @@
       "text": "그 얘기 듣고 너는 어땠어?",
       "nextId": 177
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/177.json
+++ b/public/data/story-content/5/3/177.json
@@ -9,5 +9,6 @@
       "text": "빙리의 진심을 알게 된 거구나!",
       "nextId": 178
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/178.json
+++ b/public/data/story-content/5/3/178.json
@@ -9,5 +9,6 @@
       "text": "많이 복잡했겠네.",
       "nextId": 179
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/179.json
+++ b/public/data/story-content/5/3/179.json
@@ -9,5 +9,6 @@
       "text": "무슨 일이 생긴 거야?",
       "nextId": 180
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/180.json
+++ b/public/data/story-content/5/3/180.json
@@ -9,5 +9,6 @@
       "text": "누군진 모르겠지만 잘됐다!",
       "nextId": 181
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/181.json
+++ b/public/data/story-content/5/3/181.json
@@ -13,5 +13,6 @@
       "text": "그 후로 무슨 일 없었어?",
       "nextId": 183
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/182.json
+++ b/public/data/story-content/5/3/182.json
@@ -9,5 +9,6 @@
       "text": "내가 다 설렌다.",
       "nextId": 183
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/183.json
+++ b/public/data/story-content/5/3/183.json
@@ -9,5 +9,6 @@
       "text": "좋은 생각이다. 용기를 내, 제인.",
       "nextId": 184
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/3/184.json
+++ b/public/data/story-content/5/3/184.json
@@ -8,5 +8,6 @@
     {
       "text": "마음이 준비되었으니 행복할 일만 남았네!"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/jane-video.mp4"
 }

--- a/public/data/story-content/5/4/142.json
+++ b/public/data/story-content/5/4/142.json
@@ -9,5 +9,6 @@
       "text": "혹시 엘리자베스 때문일까?",
       "nextId": 143
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/143.json
+++ b/public/data/story-content/5/4/143.json
@@ -9,5 +9,6 @@
       "text": "무슨 일이 있었던 걸까?",
       "nextId": 144
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/144.json
+++ b/public/data/story-content/5/4/144.json
@@ -9,5 +9,6 @@
       "text": "너도 걱정됐겠다...",
       "nextId": 145
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/145.json
+++ b/public/data/story-content/5/4/145.json
@@ -9,5 +9,6 @@
       "text": "그랬겠다. 그래서 어떻게 됐어?",
       "nextId": 146
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/146.json
+++ b/public/data/story-content/5/4/146.json
@@ -9,5 +9,6 @@
       "text": "드디어 제인을 보러 갔구나!",
       "nextId": 147
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/147.json
+++ b/public/data/story-content/5/4/147.json
@@ -9,5 +9,6 @@
       "text": "분명 제인도 널 보고 좋아할 거야.",
       "nextId": 148
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/148.json
+++ b/public/data/story-content/5/4/148.json
@@ -13,5 +13,6 @@
       "text": "용기를 내, 빙리!",
       "nextId": 150
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/149.json
+++ b/public/data/story-content/5/4/149.json
@@ -9,5 +9,6 @@
       "text": "언젠가.. 뭘 하고 싶은데?",
       "nextId": 150
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/public/data/story-content/5/4/150.json
+++ b/public/data/story-content/5/4/150.json
@@ -8,5 +8,6 @@
     {
       "text": "너 멋진 교훈을 얻었구나!"
     }
-  ]
+  ],
+  "videoUrl": "/images/avatars/bingley-video.mp4"
 }

--- a/src/features/story-viewer/hooks/useStoryContent.js
+++ b/src/features/story-viewer/hooks/useStoryContent.js
@@ -16,6 +16,13 @@ export default function useStoryContent(storyId, characterId, contentId) {
         setLoading(false);
         return;
       }
+      // contentId가 'complete'이면 스토리 완료 화면이므로 데이터를 로드하지 않음
+      if (contentId === 'complete') {
+        setLoading(false);
+        setData(null);
+        setError(null);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {

--- a/src/pages/StoryViewerPage.jsx
+++ b/src/pages/StoryViewerPage.jsx
@@ -69,12 +69,27 @@ export default function StoryViewerPage() {
   }
 
   const handleChoiceSelect = (nextId) => {
-    if (!nextId) {
-      // nextId가 null이면 스토리 완료 화면으로 이동
+    // nextId가 null이거나 undefined면 스토리 완료 화면으로 이동
+    if (!nextId || nextId === null) {
+      navigate(`/story/${storyId}/${characterId}/complete`);
       return;
     }
+    // nextId가 있으면 다른 씬으로 이동
     navigate(`/story/${storyId}/${characterId}/${nextId}`);
-  };
+  }
+
+  // contentId가 'complete'이면 스토리 완료 화면 표시
+  if (contentId === 'complete') {
+    return (
+      <PageContainer>
+        <StoryEndScreen 
+          storyId={storyId}
+          characterId={characterId}
+          initialCloseness={0}
+        />
+      </PageContainer>
+    );
+  }
 
   if (loading) {
     return (
@@ -99,22 +114,6 @@ export default function StoryViewerPage() {
         <LoadingText>씬을 준비하는 중…</LoadingText>
       </PageContainer>
     );
-  }
-
-  // 마지막 씬에서 nextId가 null이면 스토리 완료 화면으로 이동
-  if (contentData.reactions && contentData.reactions.length > 0) {
-    const hasNullNextId = contentData.reactions.some(reaction => reaction.nextId === null);
-    if (hasNullNextId) {
-      return (
-        <PageContainer>
-          <StoryEndScreen 
-            storyId={storyId}
-            characterId={characterId}
-            initialCloseness={0}
-          />
-        </PageContainer>
-      );
-    }
   }
 
   return (


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix로 시작해 주세요!
feat: (기능 개발)
fix: (버그 수정)
style: (CSS 스타일 수정)
format: (코드 스타일 수정)
test: (테스트 코드)
docs: (문서 작업)
refactor: (리팩토링)
lib: (라이브러리)
config: (환경설정)
chore: (기타 단순 작업)

ex) feat: 로그인 기능 구현
-->

📄 작업 내용

<!--
이 PR이 해결하려는 문제나 추가하려는 기능에 대해 간단히 설명해 주세요.
-->

📌 주요 변경 사항

<!--
어떤 부분이 바뀌었나요?
(스크린샷 등과 함께 작성하면 좋습니다.)

[ ] (예: 로그인 API 연동)

[ ] (예: 로그인 버튼 스타일 수정)
-->

동영상 로드 오류 해결
- 동영상 로드 성공: 동영상 재생
- 동영상 로드 실패: 빈 화면 표시 (에러는 콘솔에만 출력)

스토리 완료 화면 넘어가는 로직
- 마지막 씬에서 선택지 클릭 시: reaction.nextId가 null 또는 undefined
- handleChoiceSelect에서 처리: nextId가 없으면 /story/${storyId}/${characterId}/complete로 navigate
- URL의 contentId가 'complete'가 됨: 이 값은 실제 씬 ID가 아니라 완료 화면을 표시하기 위한 특별한 값
- StoryViewerPage에서 체크: contentId === 'complete'일 때 StoryEndScreen 표시

📸 스크린샷 (선택)

<!--
UI 변경이 있다면 스크린샷을 첨부해 주세요. (GIF, PNG, JPG 등)
-->

🧐 리뷰 포인트

<!--
리뷰어가 특별히 중점적으로 봐주길 바라는 부분을 자유롭게 적어주세요.
(ex: 이 부분 로직이 맞는지 봐주세요, 네이밍이 적절한지 봐주세요 등)
-->

🚀 관련 이슈

<!--
관련된 이슈 번호를 작성해 주세요.
(ex: Close #123)

이슈가 없는 경우 "없음"이라고 작성해 주세요.
-->

- 닫기: Close #
- 관련: Relate #
