### PR TITLE
feat: 성운 화면에서 잠금 행성 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VITE_USE_MOCK_DATA=true
+VITE_USE_MOCK_DATA=false
 
 # API Base URL (실제 백엔드 서버 주소)
 VITE_API_BASE_URL=https://api.classiverse.site

--- a/src/features/search/components/NebulaGrid.jsx
+++ b/src/features/search/components/NebulaGrid.jsx
@@ -27,6 +27,7 @@ const NebulaItem = styled.button`
   padding: 0;
   cursor: pointer;
   transition: transform 0.2s ease;
+  opacity: ${props => props.$isLocked ? 0.5 : 1};
 
   &:active {
     transform: scale(0.95);
@@ -34,7 +35,6 @@ const NebulaItem = styled.button`
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 0.6;
   }
 `;
 
@@ -53,8 +53,6 @@ const NebulaImage = styled.img`
   height: 100%;
   object-fit: contain;
   object-position: center;
-  filter: ${props => props.isLocked ? 'brightness(0.4)' : 'none'};
-  opacity: ${props => props.isLocked ? 0.6 : 1};
 `;
 
 const LockIcon = styled.div`
@@ -62,8 +60,8 @@ const LockIcon = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 32px;
-  height: 32px;
+  width: 18px;
+  height: 22px;
   display: ${props => props.isLocked ? 'flex' : 'none'};
   align-items: center;
   justify-content: center;
@@ -75,7 +73,6 @@ const LockImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: contain;
-  filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));
 `;
 
 const BookInfo = styled.div`
@@ -156,7 +153,8 @@ export default function NebulaGrid({ books, onBookClick, categoryLockStatus = {}
   const handleBookClick = (book) => {
     // 카테고리 또는 책이 잠겨있으면 클릭 불가
     const isCategoryLocked = categoryLockStatus[book.categoryId] === false;
-    const isBookLocked = book.unlocked === false;
+    // bookImages 배열이 비어있으면 잠금 상태
+    const isBookLocked = !book.bookImages || book.bookImages.length === 0;
     if (!isCategoryLocked && !isBookLocked && onBookClick) {
       onBookClick(book.bookId);
     }
@@ -167,9 +165,10 @@ export default function NebulaGrid({ books, onBookClick, categoryLockStatus = {}
       {rows.map((row, rowIndex) => (
         <Row key={rowIndex}>
           {row.map((book) => {
-            // 카테고리 또는 책의 잠금 상태 확인 (API에서 book.unlocked 필드 제공 시 사용)
+            // 카테고리 또는 책의 잠금 상태 확인
             const isCategoryLocked = categoryLockStatus[book.categoryId] === false;
-            const isBookLocked = book.unlocked === false;
+            // bookImages 배열이 비어있으면 잠금 상태
+            const isBookLocked = !book.bookImages || book.bookImages.length === 0;
             const isLocked = isCategoryLocked || isBookLocked;
 
             return (
@@ -177,6 +176,7 @@ export default function NebulaGrid({ books, onBookClick, categoryLockStatus = {}
                 key={book.bookId}
                 onClick={() => handleBookClick(book)}
                 disabled={isLocked}
+                $isLocked={isLocked}
               >
                 <NebulaImageWrapper>
                   <NebulaImage
@@ -190,7 +190,7 @@ export default function NebulaGrid({ books, onBookClick, categoryLockStatus = {}
                   {isLocked && (
                     <LockIcon isLocked={isLocked}>
                       <LockImage
-                        src="/images/story-lock.svg"
+                        src="/lock.svg"
                         alt="잠금"
                       />
                     </LockIcon>


### PR DESCRIPTION
<!--
PR 제목은 다음과 같은 prefix로 시작해 주세요!
feat: (기능 개발)
fix: (버그 수정)
style: (CSS 스타일 수정)
format: (코드 스타일 수정)
test: (테스트 코드)
docs: (문서 작업)
refactor: (리팩토링)
lib: (라이브러리)
config: (환경설정)
chore: (기타 단순 작업)

ex) feat: 로그인 기능 구현
-->

📄 작업 내용

<!--
이 PR이 해결하려는 문제나 추가하려는 기능에 대해 간단히 설명해 주세요.
-->
성운 책 목록 API 응답 데이터에서 bookImages 가 빈 배열이면 잠금처리

📌 주요 변경 사항

<!--
어떤 부분이 바뀌었나요?
(스크린샷 등과 함께 작성하면 좋습니다.)

[ ] (예: 로그인 API 연동)

[ ] (예: 로그인 버튼 스타일 수정)
-->

[ ] bookImages 배열이 비어있으면 잠금 상태가 되고 클릭 안됨, lock.svg 와 opacity 조절

[ ]

📸 스크린샷 (선택)

<!--
UI 변경이 있다면 스크린샷을 첨부해 주세요. (GIF, PNG, JPG 등)
-->

🧐 리뷰 포인트

<!--
리뷰어가 특별히 중점적으로 봐주길 바라는 부분을 자유롭게 적어주세요.
(ex: 이 부분 로직이 맞는지 봐주세요, 네이밍이 적절한지 봐주세요 등)
-->

🚀 관련 이슈

<!--
관련된 이슈 번호를 작성해 주세요.
(ex: Close #123)

이슈가 없는 경우 "없음"이라고 작성해 주세요.
-->

- 닫기: Close #41
- 관련: Relate #
